### PR TITLE
Use system trust store instead of cacert.pem

### DIFF
--- a/lib/httpclient/ssl_config.rb
+++ b/lib/httpclient/ssl_config.rb
@@ -288,7 +288,7 @@ class HTTPClient
 
     # interfaces for SSLSocket.
     def set_context(ctx) # :nodoc:
-      load_trust_ca unless @cacerts_loaded
+      set_default_paths unless @cacerts_loaded
       @cacerts_loaded = true
       # Verification: Use Store#verify_callback instead of SSLContext#verify*?
       ctx.cert_store = @cert_store

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -167,6 +167,8 @@ end
 
   def test_cert_store
     cfg = @client.ssl_config
+    cfg.clear_cert_store
+    cfg.load_trust_ca
     cfg.cert_store.add_cert(cert('ca.cert'))
     begin
       @client.get(@url)


### PR DESCRIPTION
Having a bot [update the cacert.pem file](https://github.com/Shopify/httpclient/commit/1fc910e2fecfeb7d75d3c4b889fc2037e645b292) is addressing the symptom, not the root cause IMO.

Bundling certificate files in a Ruby gem to work around buggy/old OpenSSL installations was a ~decade old solution. A lot has changed on the HTTPS front in the past five to ten years: 
- SSL certificates became cheaper and more prevalent to the point where it's now free and near-ubiquitous. See stats from [Google](https://transparencyreport.google.com/https/overview?hl=en) and [Let's Encrypt](https://letsencrypt.org/stats/).
- The Heartbleed vulnerability got the OpenSSL project the investments it badly needed. The Linux Foundation started the [Core Infrastructure Initiative](https://www.coreinfrastructure.org/) in response to it. Development picked up and many things were improved (see [this 2020 paper](https://arxiv.org/abs/2005.14242)).
- Bad certificate authorities faced the consequences of not handling the trust placed in them properly, e.g. [DigiNotar](https://en.wikipedia.org/wiki/DigiNotar) and [Symantec](https://arstechnica.com/information-technology/2017/03/google-takes-symantec-to-the-woodshed-for-mis-issuing-30000-https-certs/).

In short: HTTPS nowadays 'just works', operating systems update the trust store regularly, bundling certificates isn't needed anymore and can even cause issues if not updated for a long time, as evidenced by this fork existence. Using the system trust store should cause less surprises (parity with using Ruby Net::HTTP directly) and definitely is less churn of bumping a transitive dependency monthly that's not used by most apps directly.